### PR TITLE
configure: error: libdb_cxx headers missing

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -12,7 +12,7 @@ Run the following commands to install required packages:
 
 ##### Debian/Ubuntu:
 ```bash
-$ sudo apt-get install curl build-essential libtool autotools-dev automake pkg-config python3 bsdmainutils
+$ sudo apt-get install curl build-essential libtool autotools-dev automake pkg-config python3 bsdmainutils libdb4.8-dev libdb4.8++-dev
 ```
 
 ##### Fedora:


### PR DESCRIPTION
./configure fails

Missing Dep in doc builds is the reason it fails, so i added it to ubuntu build
- Missing Dependency: libdb4.8-dev libdb4.8++-dev

Regards